### PR TITLE
feat: add support for dark and light theme toggling

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1001,7 +1001,13 @@ body {
 .settings-preset-btn:hover {
   border-color: var(--color-primary);
   color: var(--color-primary);
-  background: rgba(79, 142, 247, 0.06);
+  background: var(--color-active-bg);
+}
+
+.settings-preset-btn--active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-active-bg);
 }
 
 .settings-save-row {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -20,10 +20,36 @@
   --color-delete: #ef4444;
   --color-replace: #f97316;
   --color-no-op: #64748b;
+
+  --color-hover-bg: rgba(255, 255, 255, 0.05);
+  --color-active-bg: rgba(79, 142, 247, 0.12);
+  --color-active-hover-bg: rgba(79, 142, 247, 0.16);
+  --color-divider: rgba(255, 255, 255, 0.1);
+  --color-input-bg: #0a0c12;
+  --shadow-lg: 0 8px 24px rgba(0,0,0,0.45);
+
   --radius: 8px;
   --radius-lg: 12px;
   --sidebar-width: 220px;
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+[data-theme="light"] {
+  --color-bg: #f8fafc;
+  --color-surface: #ffffff;
+  --color-surface-raised: #f1f5f9;
+  --color-border: #e2e8f0;
+  --color-border-subtle: #f1f5f9;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --color-text-subtle: #94a3b8;
+
+  --color-hover-bg: rgba(0, 0, 0, 0.05);
+  --color-active-bg: rgba(79, 142, 247, 0.1);
+  --color-active-hover-bg: rgba(79, 142, 247, 0.14);
+  --color-divider: rgba(0, 0, 0, 0.08);
+  --color-input-bg: #ffffff;
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
 * {
@@ -158,17 +184,17 @@ body {
 .sidebar__nav-item svg { flex-shrink: 0; }
 
 .sidebar__nav-item:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--color-hover-bg);
   color: var(--color-text);
 }
 
 .sidebar__nav-item--active {
-  background: rgba(79, 142, 247, 0.12);
+  background: var(--color-active-bg);
   color: var(--color-primary);
 }
 
 .sidebar__nav-item--active:hover {
-  background: rgba(79, 142, 247, 0.16);
+  background: var(--color-active-hover-bg);
   color: var(--color-primary);
 }
 
@@ -329,7 +355,7 @@ body {
 
 .upload-form__textarea {
   width: 100%;
-  background: #0a0c12;
+  background: var(--color-input-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   padding: 12px;
@@ -344,7 +370,7 @@ body {
 
 .upload-form__hint h3 { font-size: 14px; margin-bottom: 12px; }
 .upload-form__code {
-  background: #0a0c12;
+  background: var(--color-input-bg);
   padding: 12px;
   border-radius: var(--radius);
   font-size: 11px;
@@ -377,7 +403,7 @@ body {
 .graph-page__toolbar-divider {
   width: 1px;
   height: 20px;
-  background: rgba(255,255,255,0.1);
+  background: var(--color-divider);
   margin: 0 2px;
   flex-shrink: 0;
 }
@@ -402,7 +428,7 @@ body {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  box-shadow: 0 8px 24px rgba(0,0,0,0.45);
+  box-shadow: var(--shadow-lg);
   z-index: 60;
   overflow: hidden;
 }
@@ -423,7 +449,7 @@ body {
   padding: 10px 12px;
   background: transparent;
   border: none;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  border-bottom: 1px solid var(--color-divider);
   cursor: pointer;
   text-align: left;
   color: var(--color-text);
@@ -469,7 +495,7 @@ body {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  box-shadow: 0 8px 24px rgba(0,0,0,0.45);
+  box-shadow: var(--shadow-lg);
   z-index: 60;
   overflow: hidden;
 }
@@ -486,7 +512,7 @@ body {
   width: 100%;
   display: flex;
   align-items: center;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  border-bottom: 1px solid var(--color-divider);
   transition: background 0.12s;
 }
 .graph-history__item:last-child { border-bottom: none; }
@@ -529,7 +555,7 @@ body {
   transition: opacity 0.15s;
   border-radius: 4px;
 }
-.graph-history__item-pin:hover { opacity: 0.8; background: rgba(255,255,255,0.06); }
+.graph-history__item-pin:hover { opacity: 0.8; background: var(--color-hover-bg); }
 .graph-history__item-pin--active { opacity: 1; }
 
 .graph-page__canvas-area {
@@ -656,7 +682,7 @@ body {
 .node-detail__attributes pre {
   margin-top: 8px;
   font-size: 10px;
-  background: #0a0c12;
+  background: var(--color-input-bg);
   padding: 8px;
   border-radius: 4px;
   overflow-x: auto;
@@ -811,7 +837,7 @@ body {
 .attr-panel__pre {
   margin: 4px 0 0;
   font-size: 10px;
-  background: #0a0c12;
+  background: var(--color-input-bg);
   padding: 6px 8px;
   border-radius: 4px;
   overflow-x: auto;
@@ -937,7 +963,7 @@ body {
 
 .settings-input {
   width: 100%;
-  background: #0a0c14;
+  background: var(--color-input-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   padding: 9px 12px;
@@ -1173,7 +1199,7 @@ body {
   padding: 3px 9px;
   border-radius: 6px;
   border: 1px solid rgba(255,255,255,0.12);
-  background: rgba(255,255,255,0.04);
+  background: var(--color-hover-bg);
   color: var(--color-text-muted);
   font-size: 11px;
   font-weight: 500;
@@ -1682,7 +1708,7 @@ body {
   align-items: baseline;
   gap: 6px;
   padding: 5px 0;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  border-bottom: 1px solid var(--color-divider);
 }
 .cost-breakdown__row:last-child { border-bottom: none; }
 .cost-breakdown__row-name {
@@ -2313,7 +2339,7 @@ body {
   color: var(--color-text-muted);
   border: 1px solid transparent;
 }
-.btn--ghost:hover:not(:disabled) { background: rgba(255,255,255,0.06); color: var(--color-text); }
+.btn--ghost:hover:not(:disabled) { background: var(--color-hover-bg); color: var(--color-text); }
 .btn--sm { padding: 4px 10px; font-size: 12px; }
 
 /* ── Baseline banner ───────────────────────────────────────────────────── */
@@ -2407,7 +2433,7 @@ body {
   cursor: pointer;
   transition: all 0.12s;
 }
-.diff-view__tab:hover:not(:disabled) { background: rgba(255,255,255,0.06); color: var(--color-text); }
+.diff-view__tab:hover:not(:disabled) { background: var(--color-hover-bg); color: var(--color-text); }
 .diff-view__tab--active {
   background: rgba(79,142,247,0.15);
   border-color: rgba(79,142,247,0.35);
@@ -2436,12 +2462,12 @@ body {
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  border-bottom: 1px solid var(--color-divider);
   font-size: 13px;
   transition: background 0.1s;
 }
 .diff-view__row--clickable { cursor: pointer; }
-.diff-view__row--clickable:hover { background: rgba(255,255,255,0.04); }
+.diff-view__row--clickable:hover { background: var(--color-hover-bg); }
 .diff-view__row-name {
   flex: 1;
   min-width: 0;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -34,7 +34,7 @@
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-[data-theme="light"] {
+.light {
   --color-bg: #f8fafc;
   --color-surface: #ffffff;
   --color-surface-raised: #f1f5f9;

--- a/apps/web/src/app/graph/page.tsx
+++ b/apps/web/src/app/graph/page.tsx
@@ -203,7 +203,7 @@ function AttributesPanel({ attributes }: { attributes: Readonly<Record<string, u
           type="text"
           placeholder="Filter attributes…"
           value={query}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery((e.target as HTMLInputElement).value)}
           spellCheck={false}
         />
         {query && (

--- a/apps/web/src/app/graph/page.tsx
+++ b/apps/web/src/app/graph/page.tsx
@@ -203,7 +203,7 @@ function AttributesPanel({ attributes }: { attributes: Readonly<Record<string, u
           type="text"
           placeholder="Filter attributes…"
           value={query}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery((e.target as HTMLInputElement).value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery(e.currentTarget.value)}
           spellCheck={false}
         />
         {query && (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import ClientShell from "@/components/layout/ClientShell";
+import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -9,9 +10,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
-        <ClientShell>{children}</ClientShell>
+        <ThemeProvider>
+          <ClientShell>{children}</ClientShell>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -11,6 +11,23 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var theme = localStorage.getItem('tf-viz:theme');
+                  var supportDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches === true;
+                  if (!theme && supportDarkMode) theme = 'dark';
+                  if (!theme && !supportDarkMode) theme = 'light';
+                  if (theme === 'light') document.documentElement.classList.add('light');
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+      </head>
       <body>
         <ThemeProvider>
           <ClientShell>{children}</ClientShell>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,4 +1,5 @@
 import { LlmSettings } from "@/components/settings/LlmSettings";
+import { ThemeSettings } from "@/components/settings/ThemeSettings";
 
 export default function SettingsPage() {
   return (
@@ -6,6 +7,7 @@ export default function SettingsPage() {
       <h1 className="page-title">Settings</h1>
       <p className="page-subtitle">Configure providers and preferences for Terraform Viz.</p>
       <div className="settings-page">
+        <ThemeSettings />
         <LlmSettings />
       </div>
     </div>

--- a/apps/web/src/components/graph/TwoDGraph.tsx
+++ b/apps/web/src/components/graph/TwoDGraph.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useCallback, memo } from "react";
 import * as d3 from "d3";
 import { ChangeAction, CloudProvider, ResourceLayer, type GraphModel, type GraphNode } from "@terraform-viz/graph-schema";
 import { estimateCost } from "@/lib/pricing-estimates";
+import { useTheme } from "../layout/ThemeProvider";
 
 // ── Layer ordering (top → bottom in diagram) ───────────────────────────────
 const LAYER_ORDER: ResourceLayer[] = [
@@ -142,6 +143,7 @@ interface TwoDGraphProps {
 }
 
 function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
+  const { theme } = useTheme();
   const svgRef = useRef<SVGSVGElement>(null);
   const stableSelect = useCallback(onNodeSelect, [onNodeSelect]);
   // Stable model ref so the ResizeObserver callback can always read current model
@@ -157,6 +159,8 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
     const svgW = Math.max(viewW, 960);
     const model = modelRef.current;
 
+    const isLight = theme === "light";
+
     const svg = d3.select<SVGSVGElement, unknown>(el);
     svg.selectAll("*").remove();
 
@@ -169,7 +173,7 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
       .attr("refX", 9).attr("refY", 0)
       .attr("markerWidth", 5).attr("markerHeight", 5)
       .attr("orient", "auto")
-      .append("path").attr("d", "M0,-4L9,0L0,4").attr("fill", "#4a5568");
+      .append("path").attr("d", "M0,-4L9,0L0,4").attr("fill", isLight ? "#94a3b8" : "#4a5568");
 
     const filter = defs.append("filter")
       .attr("id", "node-shadow")
@@ -177,7 +181,7 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
       .attr("width", "160%").attr("height", "160%");
     filter.append("feDropShadow")
       .attr("dx", 0).attr("dy", 2).attr("stdDeviation", 4)
-      .attr("flood-color", "#000").attr("flood-opacity", 0.35);
+      .attr("flood-color", "#000").attr("flood-opacity", isLight ? 0.15 : 0.35);
 
     // ── Canvas & zoom ─────────────────────────────────────────────────────
     const g = svg.append("g");
@@ -203,15 +207,15 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
         .attr("x", LABEL_COL).attr("y", y + 6)
         .attr("width", svgW - LABEL_COL - 10).attr("height", BAND_H - 12)
         .attr("rx", 12).attr("fill", bg)
-        .attr("stroke", color).attr("stroke-width", 1).attr("stroke-opacity", 0.3);
+        .attr("stroke", color).attr("stroke-width", 1).attr("stroke-opacity", isLight ? 0.2 : 0.3);
 
       // Label column background
       g.append("rect")
         .attr("x", 4).attr("y", y + 6)
         .attr("width", LABEL_COL - 12).attr("height", BAND_H - 12)
         .attr("rx", 8)
-        .attr("fill", "rgba(255,255,255,0.015)")
-        .attr("stroke", color).attr("stroke-width", 0.5).attr("stroke-opacity", 0.25);
+        .attr("fill", isLight ? "rgba(0,0,0,0.02)" : "rgba(255,255,255,0.015)")
+        .attr("stroke", color).attr("stroke-width", 0.5).attr("stroke-opacity", isLight ? 0.15 : 0.25);
 
       // Accent left bar
       g.append("rect")
@@ -253,7 +257,7 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
       g.append("path")
         .attr("d", `M ${stX} ${stY} C ${stX} ${stY + cp}, ${endX} ${endY - cp}, ${endX} ${endY}`)
         .attr("fill", "none")
-        .attr("stroke", "#3a4155").attr("stroke-width", 1.5).attr("opacity", 0.65)
+        .attr("stroke", isLight ? "#cbd5e1" : "#3a4155").attr("stroke-width", 1.5).attr("opacity", 0.65)
         .attr("marker-end", "url(#arrowhead)");
     }
 
@@ -276,7 +280,7 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
 
       // Drop shadow
       nodeG.append("circle")
-        .attr("r", NODE_R + 2).attr("fill", "rgba(0,0,0,0.28)").attr("cy", 3);
+        .attr("r", NODE_R + 2).attr("fill", isLight ? "rgba(0,0,0,0.1)" : "rgba(0,0,0,0.28)").attr("cy", 3);
 
       // Main circle — border uses action colour when changed
       nodeG.append("circle")
@@ -300,7 +304,7 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
           .attr("r", badgeR)
           .attr("cx", bx).attr("cy", by)
           .attr("fill", actColor)
-          .attr("stroke", "#0d0f18").attr("stroke-width", 1.5);
+          .attr("stroke", isLight ? "#fff" : "#0d0f18").attr("stroke-width", 1.5);
         nodeG.append("text")
           .attr("text-anchor", "middle").attr("dominant-baseline", "middle")
           .attr("x", bx).attr("y", by)
@@ -334,7 +338,7 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
         ? graphNode.name.slice(0, 12) + "…" : graphNode.name;
       nodeG.append("text")
         .attr("text-anchor", "middle").attr("y", NODE_R + 14)
-        .attr("font-size", 9.5).attr("fill", "#cbd5e1").attr("pointer-events", "none")
+        .attr("font-size", 9.5).attr("fill", isLight ? "#334155" : "#cbd5e1").attr("pointer-events", "none")
         .attr("font-family", "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif")
         .attr("font-weight", "600")
         .text(displayName);
@@ -392,15 +396,15 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
     legendG.append("rect")
       .attr("width", lgW).attr("height", lgH)
       .attr("rx", 7)
-      .attr("fill", "rgba(13,15,24,0.88)")
-      .attr("stroke", "rgba(255,255,255,0.09)").attr("stroke-width", 1);
+      .attr("fill", isLight ? "rgba(255,255,255,0.92)" : "rgba(13,15,24,0.88)")
+      .attr("stroke", isLight ? "rgba(0,0,0,0.1)" : "rgba(255,255,255,0.09)").attr("stroke-width", 1);
 
     legendItems.forEach(({ color, symbol, label }, i) => {
       const ly = lgPad + i * lgItemH + lgItemH / 2;
       legendG.append("circle")
         .attr("r", 8).attr("cx", lgPad + 8).attr("cy", ly)
         .attr("fill", color)
-        .attr("stroke", "#0d0f18").attr("stroke-width", 1);
+        .attr("stroke", isLight ? "#fff" : "#0d0f18").attr("stroke-width", 1);
       legendG.append("text")
         .attr("x", lgPad + 8).attr("y", ly)
         .attr("text-anchor", "middle").attr("dominant-baseline", "middle")
@@ -412,7 +416,7 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
         .attr("x", lgPad + 22).attr("y", ly)
         .attr("dominant-baseline", "middle")
         .attr("font-size", 10.5)
-        .attr("fill", "#94a3b8")
+        .attr("fill", isLight ? "#475569" : "#94a3b8")
         .attr("font-family", "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif")
         .text(label);
     });
@@ -437,13 +441,13 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
       plgG.append("rect")
         .attr("width", plgW).attr("height", plgH)
         .attr("rx", 7)
-        .attr("fill", "rgba(13,15,24,0.88)")
-        .attr("stroke", "rgba(255,255,255,0.09)").attr("stroke-width", 1);
+        .attr("fill", isLight ? "rgba(255,255,255,0.92)" : "rgba(13,15,24,0.88)")
+        .attr("stroke", isLight ? "rgba(0,0,0,0.1)" : "rgba(255,255,255,0.09)").attr("stroke-width", 1);
       plgG.append("text")
         .attr("x", plgPad).attr("y", plgPad + 9)
         .attr("font-size", 8.5).attr("font-weight", "700")
         .attr("letter-spacing", "0.5")
-        .attr("fill", "#475569")
+        .attr("fill", isLight ? "#64748b" : "#475569")
         .attr("font-family", "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif")
         .text("PROVIDERS");
 
@@ -468,12 +472,12 @@ function _TwoDGraph({ model, onNodeSelect }: TwoDGraphProps) {
           .attr("x", plgPad + 30).attr("y", py)
           .attr("dominant-baseline", "middle")
           .attr("font-size", 10)
-          .attr("fill", "#94a3b8")
+          .attr("fill", isLight ? "#475569" : "#94a3b8")
           .attr("font-family", "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif")
           .text(label);
       });
     }
-  }, [stableSelect]);
+  }, [stableSelect, theme]);
 
   // Redraw on model change
   useEffect(() => { draw(); }, [draw, model]);

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ThemeToggle } from "./ThemeToggle";
 
 function IconGraph() {
   return (
@@ -132,6 +133,7 @@ export function Sidebar() {
       </div>
 
       <div className="sidebar__footer">
+        <ThemeToggle />
         <Link
           href="/settings"
           className={`sidebar__nav-item${pathname === "/settings" ? " sidebar__nav-item--active" : ""}`}

--- a/apps/web/src/components/layout/ThemeProvider.tsx
+++ b/apps/web/src/components/layout/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from "react";
 
 type Theme = "dark" | "light";
 
@@ -17,6 +17,14 @@ const THEME_KEY = "tf-viz:theme";
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>("dark");
 
+  const applyTheme = useCallback((t: Theme) => {
+    if (t === "light") {
+      document.documentElement.classList.add("light");
+    } else {
+      document.documentElement.classList.remove("light");
+    }
+  }, []);
+
   useEffect(() => {
     const stored = localStorage.getItem(THEME_KEY) as Theme;
     if (stored === "light" || stored === "dark") {
@@ -28,15 +36,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setThemeState(initialTheme);
       applyTheme(initialTheme);
     }
-  }, []);
-
-  const applyTheme = (t: Theme) => {
-    if (t === "light") {
-      document.documentElement.classList.add("light");
-    } else {
-      document.documentElement.classList.remove("light");
-    }
-  };
+  }, [applyTheme]);
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);

--- a/apps/web/src/components/layout/ThemeProvider.tsx
+++ b/apps/web/src/components/layout/ThemeProvider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+type Theme = "dark" | "light";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_KEY = "tf-viz:theme";
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("dark");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(THEME_KEY) as Theme;
+    if (stored === "light" || stored === "dark") {
+      setThemeState(stored);
+      document.documentElement.setAttribute("data-theme", stored);
+    } else {
+      // Default to dark or system preference
+      const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+      if (prefersLight) {
+        setThemeState("light");
+        document.documentElement.setAttribute("data-theme", "light");
+      }
+    }
+  }, []);
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+    localStorage.setItem(THEME_KEY, newTheme);
+    document.documentElement.setAttribute("data-theme", newTheme);
+  };
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/apps/web/src/components/layout/ThemeProvider.tsx
+++ b/apps/web/src/components/layout/ThemeProvider.tsx
@@ -21,21 +21,27 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const stored = localStorage.getItem(THEME_KEY) as Theme;
     if (stored === "light" || stored === "dark") {
       setThemeState(stored);
-      document.documentElement.setAttribute("data-theme", stored);
+      applyTheme(stored);
     } else {
-      // Default to dark or system preference
       const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
-      if (prefersLight) {
-        setThemeState("light");
-        document.documentElement.setAttribute("data-theme", "light");
-      }
+      const initialTheme = prefersLight ? "light" : "dark";
+      setThemeState(initialTheme);
+      applyTheme(initialTheme);
     }
   }, []);
+
+  const applyTheme = (t: Theme) => {
+    if (t === "light") {
+      document.documentElement.classList.add("light");
+    } else {
+      document.documentElement.classList.remove("light");
+    }
+  };
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
     localStorage.setItem(THEME_KEY, newTheme);
-    document.documentElement.setAttribute("data-theme", newTheme);
+    applyTheme(newTheme);
   };
 
   const toggleTheme = () => {

--- a/apps/web/src/components/layout/ThemeToggle.tsx
+++ b/apps/web/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useTheme } from "./ThemeProvider";
+
+function IconSun() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function IconMoon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+    </svg>
+  );
+}
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="sidebar__nav-item"
+      style={{ background: "transparent", border: "none", width: "100%", justifyContent: "flex-start" }}
+      title={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+    >
+      {theme === "dark" ? <IconSun /> : <IconMoon />}
+      <span>{theme === "dark" ? "Light Mode" : "Dark Mode"}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/layout/ThemeToggle.tsx
+++ b/apps/web/src/components/layout/ThemeToggle.tsx
@@ -49,9 +49,10 @@ export function ThemeToggle() {
 
   return (
     <button
+      type="button"
       onClick={toggleTheme}
       className="sidebar__nav-item"
-      style={{ background: "transparent", border: "none", width: "100%", justifyContent: "flex-start" }}
+      style={{ border: "none", width: "100%", justifyContent: "flex-start" }}
       title={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
     >
       {theme === "dark" ? <IconSun /> : <IconMoon />}

--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTheme } from "../../components/layout/ThemeProvider";
+import { useTheme } from "../layout/ThemeProvider";
 
 export function ThemeSettings() {
   const { theme, setTheme } = useTheme();
@@ -16,16 +16,16 @@ export function ThemeSettings() {
         <label>Theme</label>
         <div className="settings-presets">
           <button
+            type="button"
             onClick={() => setTheme("light")}
             className={`settings-preset-btn${theme === "light" ? " settings-preset-btn--active" : ""}`}
-            style={theme === "light" ? { borderColor: "var(--color-primary)", color: "var(--color-primary)", background: "rgba(79, 142, 247, 0.06)" } : {}}
           >
             Light
           </button>
           <button
+            type="button"
             onClick={() => setTheme("dark")}
             className={`settings-preset-btn${theme === "dark" ? " settings-preset-btn--active" : ""}`}
-            style={theme === "dark" ? { borderColor: "var(--color-primary)", color: "var(--color-primary)", background: "rgba(79, 142, 247, 0.06)" } : {}}
           >
             Dark
           </button>

--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTheme } from "../../components/layout/ThemeProvider";
+
+export function ThemeSettings() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <section className="settings-section">
+      <h2 className="settings-section__title">Appearance</h2>
+      <p className="settings-section__subtitle">
+        Choose how TerraViz looks to you.
+      </p>
+
+      <div className="settings-field">
+        <label>Theme</label>
+        <div className="settings-presets">
+          <button
+            onClick={() => setTheme("light")}
+            className={`settings-preset-btn${theme === "light" ? " settings-preset-btn--active" : ""}`}
+            style={theme === "light" ? { borderColor: "var(--color-primary)", color: "var(--color-primary)", background: "rgba(79, 142, 247, 0.06)" } : {}}
+          >
+            Light
+          </button>
+          <button
+            onClick={() => setTheme("dark")}
+            className={`settings-preset-btn${theme === "dark" ? " settings-preset-btn--active" : ""}`}
+            style={theme === "dark" ? { borderColor: "var(--color-primary)", color: "var(--color-primary)", background: "rgba(79, 142, 247, 0.06)" } : {}}
+          >
+            Dark
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
 ## Description
This PR implements a full dark and light theme system for TerraViz, resolving issue #5. It allows users to switch between themes via a quick toggle in the sidebar or through the settings page.
 ## Key Changes
 - **Theme Engine**: Implemented a `ThemeProvider` using React Context to manage theme state and persist user preference in `localStorage`.
 - **UI Components**: 
    - Added a Sun/Moon `ThemeToggle` component to the Sidebar footer.
     - Added an Appearance section to the Settings page.
 - **Dynamic Graph Rendering**: Updated the D3-based `TwoDGraph` to react to theme changes, updating colors for edges, nodes, legends, and shadows for optimal readability in both modes.
 - **CSS Variables**: Refactored `globals.css` to use CSS variables for semi-transparent backgrounds and shadows, ensuring consistent styling across themes.
 ## Verification
- Verified theme persistence after page reloads.
 - Verified SVG graph redraws immediately upon theme switch.
 - Checked accessibility and contrast for both themes.